### PR TITLE
refactor: centralize AlpineComponent type

### DIFF
--- a/astro-src/components/AddBuildingForm.astro
+++ b/astro-src/components/AddBuildingForm.astro
@@ -148,13 +148,7 @@
 </div>
 
 <script>
-// Alpine.js magic properties type
-type AlpineComponent<T = {}> = T & {
-    $dispatch: (event: string, detail?: any) => void;
-    $root: HTMLElement;
-    $el: HTMLElement;
-    $watch: (expression: string, callback: (value: any) => void) => void;
-};
+import type { AlpineComponent } from "../types/alpine";
 
 type AddBuildingFormData = AlpineComponent<{
     buildingID: string;

--- a/astro-src/components/BuildingManager.astro
+++ b/astro-src/components/BuildingManager.astro
@@ -129,13 +129,7 @@ const emptyUnitTypes: any[] = [];
 </div>
 
 <script>
-// Alpine.js magic properties type
-type AlpineComponent<T = {}> = T & {
-    $dispatch: (event: string, detail?: any) => void;
-    $root: HTMLElement;
-    $el: HTMLElement;
-    $watch: (expression: string, callback: (value: any) => void) => void;
-};
+import type { AlpineComponent } from "../types/alpine";
 
 type BuildingManagerData = AlpineComponent<{
     loading: boolean;

--- a/astro-src/components/BuildingsComponent.astro
+++ b/astro-src/components/BuildingsComponent.astro
@@ -53,13 +53,7 @@ const apiURL = Resource.API.url;
 </div>
 
 <script>
-// Alpine.js magic properties type
-type AlpineComponent<T = {}> = T & {
-    $dispatch: (event: string, detail?: any) => void;
-    $root: HTMLElement;
-    $el: HTMLElement;
-    $watch: (expression: string, callback: (value: any) => void) => void;
-};
+import type { AlpineComponent } from "../types/alpine";
 
 type Building = {
     buildingID: string;

--- a/astro-src/components/BuildingsList.astro
+++ b/astro-src/components/BuildingsList.astro
@@ -40,13 +40,7 @@ export interface Props {
 </div>
 
 <script>
-// Alpine.js magic properties type
-type AlpineComponent<T = {}> = T & {
-    $dispatch: (event: string, detail?: any) => void;
-    $root: HTMLElement;
-    $el: HTMLElement;
-    $watch: (expression: string, callback: (value: any) => void) => void;
-};
+import type { AlpineComponent } from "../types/alpine";
 
 type Building = {
     buildingID: string;

--- a/astro-src/types/alpine.ts
+++ b/astro-src/types/alpine.ts
@@ -1,0 +1,6 @@
+export type AlpineComponent<T = {}> = T & {
+    $dispatch: (event: string, detail?: any) => void;
+    $root: HTMLElement;
+    $el: HTMLElement;
+    $watch: (expression: string, callback: (value: any) => void) => void;
+};


### PR DESCRIPTION
## Summary
- add shared `AlpineComponent` type
- update building-related components to import shared type

## Testing
- `bunx tsc -p tsconfig.json` *(fails: Property 'PhotosBucket' does not exist on type 'Resource')*
- `bun test`


------
https://chatgpt.com/codex/tasks/task_e_689cc64d7dac832f8669267cfdc81bc4