### PR TITLE
fix: consolidate dynamic class attributes

### DIFF
--- a/astro-src/components/AddBuildingForm.astro
+++ b/astro-src/components/AddBuildingForm.astro
@@ -14,7 +14,7 @@
         <!-- Autocomplete dropdown using proper DaisyUI structure -->
         <div
           class="dropdown w-full"
-          class="{ 'dropdown-open': showSuggestions }"
+          :class="{ 'dropdown-open': showSuggestions }"
         >
             <label class="floating-label mb-2 w-full relative">
                 <span>Street</span>
@@ -77,7 +77,7 @@
                     <li>
                         <a
                           class="text-sm py-2 px-3 cursor-pointer rounded-btn"
-                          class="{ 'bg-primary text-primary-content': selectedIndex === index }"
+                          :class="{ 'bg-primary text-primary-content': selectedIndex === index }"
                           :id="`suggestion-${index}`"
                           :aria-selected="selectedIndex === index"
                             role="option"


### PR DESCRIPTION
## Summary
- use `:class` on dropdown and suggestion elements to avoid duplicate `class` attributes

## Testing
- `bunx eslint astro-src/components/AddBuildingForm.astro`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_68a799d967a8832f9204666923c73d16