### PR TITLE
refactor: register alpine data via Alpine.data

### DIFF
--- a/astro-src/components/AddBuildingForm.astro
+++ b/astro-src/components/AddBuildingForm.astro
@@ -620,14 +620,10 @@ function addBuildingFormData(): AddBuildingFormData {
     } as AddBuildingFormData;
 }
 
-// Make available globally for Alpine.js
-declare global {
-    interface Window {
-        addBuildingFormData: typeof addBuildingFormData
-    }
-}
-
-window.addBuildingFormData = addBuildingFormData;
+// Register with Alpine
+document.addEventListener('alpine:init', () => {
+    Alpine.data('addBuildingFormData', addBuildingFormData);
+});
 </script>
 
 <style>

--- a/astro-src/components/BuildingManager.astro
+++ b/astro-src/components/BuildingManager.astro
@@ -235,14 +235,10 @@ function buildingManagerData(): BuildingManagerData {
     } as BuildingManagerData;
 }
 
-// Make available globally for Alpine.js
-declare global {
-    interface Window {
-        buildingManagerData: typeof buildingManagerData
-    }
-}
-
-window.buildingManagerData = buildingManagerData;
+// Register with Alpine
+document.addEventListener('alpine:init', () => {
+    Alpine.data('buildingManagerData', buildingManagerData);
+});
 </script>
 
 <style>

--- a/astro-src/components/BuildingsComponent.astro
+++ b/astro-src/components/BuildingsComponent.astro
@@ -226,14 +226,10 @@ function buildingsComponentData(): BuildingsComponentData {
     } as BuildingsComponentData;
 }
 
-// Make available globally for Alpine.js
-declare global {
-    interface Window {
-        buildingsComponentData: typeof buildingsComponentData
-    }
-}
-
-window.buildingsComponentData = buildingsComponentData;
+// Register with Alpine
+document.addEventListener('alpine:init', () => {
+    Alpine.data('buildingsComponentData', buildingsComponentData);
+});
 </script>
 
 <style>

--- a/astro-src/components/BuildingsList.astro
+++ b/astro-src/components/BuildingsList.astro
@@ -183,14 +183,10 @@ function buildingsListData(): BuildingsListData {
     } as BuildingsListData;
 }
 
-// Make available globally for Alpine.js
-declare global {
-    interface Window {
-        buildingsListData: typeof buildingsListData
-    }
-}
-
-window.buildingsListData = buildingsListData;
+// Register with Alpine
+document.addEventListener('alpine:init', () => {
+    Alpine.data('buildingsListData', buildingsListData);
+});
 </script>
 
 <style>

--- a/astro-src/components/ModelAmenitiesManager.astro
+++ b/astro-src/components/ModelAmenitiesManager.astro
@@ -26,7 +26,7 @@ const unitTypesMap = Object.fromEntries(
 
 <script is:inline>
 // Used by Alpine.js x-data attribute
-window.modelAmenitiesManagerData = function modelAmenitiesManagerData() {
+function modelAmenitiesManagerData() {
     return {
         apiURL: document.querySelector('[data-api-url]')?.dataset.apiUrl || '',
         buildingID: document.querySelector('[data-building-id]')?.dataset.buildingId || '',
@@ -164,7 +164,11 @@ window.modelAmenitiesManagerData = function modelAmenitiesManagerData() {
             return amenities.slice(0, 3).map(a => a.name).join(', ') + ' +' + (amenities.length - 3) + ' more';
         }
     };
-};
+}
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('modelAmenitiesManagerData', modelAmenitiesManagerData);
+});
 </script>
 
 <div x-data="modelAmenitiesManagerData()" class="model-amenities-manager" data-api-url={_apiURL} data-building-id={buildingID} data-unit-types={JSON.stringify(unitTypesMap)}>

--- a/astro-src/components/UnitTypeCard.astro
+++ b/astro-src/components/UnitTypeCard.astro
@@ -44,16 +44,10 @@ interface UnitTypeCardComponent {
     setDepositPartialRefundPercentage(value: string): void
 }
 
-// Declare the global window property for TypeScript
-declare global {
-    interface Window {
-        unitTypeCardData: (unitTypeData: UnitTypeData, buildingAmenitiesData: Amenity[], apiUrlData: string) => UnitTypeCardComponent
-    }
-}
 ---
 <script is:inline>
 // Used by Alpine.js x-data attribute
-window.unitTypeCardData = function unitTypeCardData(unitTypeData, buildingAmenitiesData, apiUrlData) {
+function unitTypeCardData(unitTypeData, buildingAmenitiesData, apiUrlData) {
     return {
         unitType: unitTypeData,
         originalUnitType: JSON.parse(JSON.stringify(unitTypeData)), // Deep copy for original state
@@ -248,7 +242,11 @@ window.unitTypeCardData = function unitTypeCardData(unitTypeData, buildingAmenit
             this.unitType.deposit.partialRefundPercentage = percentage;
         }
     };
-};
+}
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('unitTypeCardData', unitTypeCardData);
+});
 </script>
 
 <div x-data="unitTypeCardData(unitType, _buildingAmenities, _apiURL)" x-init="init(); $watch('unitType', () => saveUnitType(this))" class="card bg-base-100 shadow-xl" :class="{'opacity-50': saving}" data-testid="unit-type-card">

--- a/astro-src/components/forms/LocationMapPicker.astro
+++ b/astro-src/components/forms/LocationMapPicker.astro
@@ -165,7 +165,6 @@ Location was estimated from the address. Click on the map to place the pin exact
 // Type declarations for Alpine.js magic properties and global variables
 declare global {
     interface Window {
-        locationMapData: typeof locationMapData
         L: typeof import('leaflet')
     }
 }
@@ -581,10 +580,10 @@ function locationMapData(
     };
 }
 
-// Make the function globally available
-if(typeof window !== 'undefined') {
-    window.locationMapData = locationMapData;
-}
+// Register with Alpine
+document.addEventListener('alpine:init', () => {
+    Alpine.data('locationMapData', locationMapData);
+});
 </script>
 
 <style>

--- a/astro-src/components/unit-card/UnitCardProvider.astro
+++ b/astro-src/components/unit-card/UnitCardProvider.astro
@@ -63,7 +63,7 @@ const safeLog = {
     }
 };
 
-window.unitCardData = function unitCardData() {
+function unitCardData() {
     return {
         unit: null,
         originalUnit: null,
@@ -658,7 +658,11 @@ window.unitCardData = function unitCardData() {
             }
         }
     };
-};
+}
+
+document.addEventListener('alpine:init', () => {
+    Alpine.data('unitCardData', unitCardData);
+});
 </script>
 
 <li

--- a/astro-src/components/unit-type-form/UnitTypeFormProvider.astro
+++ b/astro-src/components/unit-type-form/UnitTypeFormProvider.astro
@@ -19,40 +19,15 @@ if(!_apiURL) {
     throw new Error('API URL not configured');
 } // Validate and mark as used for TypeScript
 
-// Declare the global window property for TypeScript
-declare global {
-    interface Window {
-        unitTypeFormData: (_apiUrlData: string, _buildingIdData: string) => UnitTypeFormState
-        unitTypeFormOnSuccess?: () => void
-    }
-}
 ---
-
-<script>
-// Import the state management function
+<script type="module">
 import { createUnitTypeFormState } from '../../lib/unit-type-form';
 
-// Declare global type for Alpine.js
-declare global {
-    interface Window {
-        createUnitTypeFormState: typeof createUnitTypeFormState
-    }
-}
-
-// Make the state creation function available globally for Alpine.js
-if(typeof window !== 'undefined') {
-    window.createUnitTypeFormState = createUnitTypeFormState;
-}
-</script>
-
-<script define:vars={{ _apiURL, buildingID }} is:inline>
-
-// Used by Alpine.js x-data attribute - wrapper for the state function
-
-window.unitTypeFormData = function unitTypeFormData(_apiUrlData, _buildingIdData) {
-    // Variables _apiURL and buildingID are injected by Astro's define:vars
-    return window.createUnitTypeFormState(_apiURL, buildingID);
-};
+document.addEventListener('alpine:init', () => {
+    Alpine.data('unitTypeFormData', (apiUrlData, buildingIdData) =>
+        createUnitTypeFormState(apiUrlData, buildingIdData)
+    );
+});
 </script>
 
 {onSuccess && (
@@ -66,7 +41,12 @@ window.unitTypeFormData = function unitTypeFormData(_apiUrlData, _buildingIdData
     </script>
 )}
 
-<div x-data="unitTypeFormData(_apiURL, buildingID)" class="unit-type-form">
+<div
+  x-data="unitTypeFormData($el.dataset.apiUrl, $el.dataset.buildingId)"
+  class="unit-type-form"
+  data-api-url={_apiURL}
+  data-building-id={buildingID}
+>
     <!-- Toggle Button -->
     <button
       class="btn btn-primary"

--- a/astro-src/lib/unit-card/unitCardState.ts
+++ b/astro-src/lib/unit-card/unitCardState.ts
@@ -420,16 +420,9 @@ function unitCardStateObject(): UnitCardState {
     };
 }
 
-/**
- * Global window function for Alpine.js to use
- */
-declare global {
-    interface Window {
-        unitCardData: typeof createUnitCardState
-    }
-}
-
-// Expose to global for Alpine.js usage
+// Register with Alpine
 if(typeof window !== 'undefined') {
-    window.unitCardData = createUnitCardState;
+    document.addEventListener('alpine:init', () => {
+        window.Alpine.data('unitCardData', createUnitCardState);
+    });
 }


### PR DESCRIPTION
## Summary
- register UnitTypeCard state via `Alpine.data` and remove global window declaration
- replace global `window.*Data` assignments with `Alpine.data` in various Alpine components
- drop obsolete Window interface entries

## Testing
- `bun test` *(fails: Unhandled error between tests, 0 pass, 93 fail, 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a0ae9c8832faf764f2c742a3aec