### PR TITLE
feat(forms): add id handling to base inputs

### DIFF
--- a/astro-src/components/forms/BaseInput.astro
+++ b/astro-src/components/forms/BaseInput.astro
@@ -1,7 +1,9 @@
 ---
 import _ from 'lodash';
+import crypto from 'node:crypto';
 
 export interface Props {
+    id?: string
     name: string
     label?: string
     placeholder?: string
@@ -27,6 +29,7 @@ export interface Props {
 }
 
 const {
+    id,
     name,
     label,
     placeholder,
@@ -50,6 +53,8 @@ const {
     floatingLabel = false,
     inputSize = 'full',
 } = Astro.props;
+
+const inputId = id || crypto.randomUUID();
 
 // Determine if we should show the label
 const shouldShowLabel = showLabel && label;
@@ -84,7 +89,7 @@ const containerClasses = _.compact([
 
 <div class={containerClasses}>
     {shouldShowLabel && !floatingLabel && (
-        <label class="label">
+        <label class="label" for={inputId}>
             <span class="label-text">
                 {label}
                 {required && <span class="text-error font-bold text-sm">*</span>}
@@ -94,7 +99,7 @@ const containerClasses = _.compact([
 
     {floatingLabel
         ? (
-            <label class="floating-label">
+            <label class="floating-label" for={inputId}>
                 {shouldShowLabel && (
                     <span>
                         {label}
@@ -102,6 +107,7 @@ const containerClasses = _.compact([
                     </span>
                 )}
                 <input
+                  id={inputId}
                   type={type}
                   name={name}
                   placeholder={placeholder || label}
@@ -122,6 +128,7 @@ const containerClasses = _.compact([
         )
         : (
             <input
+              id={inputId}
               type={type}
               name={name}
               placeholder={placeholder}

--- a/astro-src/components/forms/BaseSelect.astro
+++ b/astro-src/components/forms/BaseSelect.astro
@@ -1,5 +1,6 @@
 ---
 import _ from 'lodash';
+import crypto from 'node:crypto';
 
 export interface SelectOption {
     value: string | number
@@ -8,6 +9,7 @@ export interface SelectOption {
 }
 
 export interface Props {
+    id?: string
     name: string
     label?: string
     placeholder?: string
@@ -28,6 +30,7 @@ export interface Props {
 }
 
 const {
+    id,
     name,
     label,
     placeholder,
@@ -46,6 +49,8 @@ const {
     multiple = false,
     size,
 } = Astro.props;
+
+const selectId = id || crypto.randomUUID();
 
 // Normalize options to SelectOption format
 const normalizedOptions: SelectOption[] = options
@@ -72,7 +77,7 @@ const containerClasses = _.compact([
 ]).join(' ');
 ---
 
-<label class={containerClasses}>
+<label class={containerClasses} for={selectId}>
     {shouldShowLabel && !floatingLabel && (
         <span class="label-text">
             {label}
@@ -80,6 +85,7 @@ const containerClasses = _.compact([
         </span>
     )}
     <select
+      id={selectId}
       name={name}
       class={selectClasses}
       required={required}


### PR DESCRIPTION
## Summary
- assign consistent ids to BaseInput and BaseSelect elements
- link labels via for attribute

## Testing
- `bun test` *(fails: Unhandled error between tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a79a055664832fae75503464e9bc2c