### PR TITLE
refactor: consolidate custom CSS into global styles

### DIFF
--- a/astro-src/components/AddBuildingForm.astro
+++ b/astro-src/components/AddBuildingForm.astro
@@ -61,7 +61,7 @@
 
             <!-- Autocomplete dropdown using DaisyUI dropdown-content -->
             <ul
-              class="dropdown-content menu bg-base-100 rounded-box z-50 w-full max-h-60 overflow-y-auto shadow-lg border border-base-300"
+              class="dropdown-content menu bg-base-100 rounded-box z-50 w-full max-h-60 overflow-y-auto shadow-lg border border-base-300 flex flex-col flex-nowrap p-1"
               x-show="showSuggestions || (!loading && suggestions.length === 0 && street.length >= 3)"
               x-transition:enter="transition ease-out duration-100"
               x-transition:enter-start="opacity-0 scale-95"
@@ -76,7 +76,7 @@
                 <template x-for="(suggestion, index) in suggestions" :key="suggestion.displayText + index">
                     <li>
                         <a
-                          class="text-sm py-2 px-3 cursor-pointer rounded-btn"
+                          class="text-sm py-1.5 px-3 cursor-pointer rounded-btn gap-1.5 min-h-0"
                           class="{ 'bg-primary text-primary-content': selectedIndex === index }"
                           :id="`suggestion-${index}`"
                           :aria-selected="selectedIndex === index"
@@ -630,29 +630,4 @@ declare global {
 window.addBuildingFormData = addBuildingFormData;
 </script>
 
-<style>
-/* Force single column layout and prevent wrapping */
-.dropdown-content.menu {
-    flex-flow: column nowrap !important;
-    width: 100% !important;
-}
 
-/* Compact spacing for autocomplete dropdown */
-.dropdown .menu {
-    padding: 0.25rem;
-}
-
-.dropdown .menu li > a {
-    padding-top: 0.375rem;
-    padding-bottom: 0.375rem;
-    padding-left: 0.75rem;
-    padding-right: 0.75rem;
-    min-height: auto;
-    gap: 0.375rem;
-}
-
-/* Ensure dropdown appears above other content */
-.dropdown-content {
-    z-index: 50;
-}
-</style>

--- a/astro-src/components/BuildingManager.astro
+++ b/astro-src/components/BuildingManager.astro
@@ -245,15 +245,4 @@ declare global {
 window.buildingManagerData = buildingManagerData;
 </script>
 
-<style>
 
-.building-manager {
-    min-height: 200px;
-}
-
-/* Smooth loading transitions */
-[x-cloak] {
-    display: none !important;
-}
-
-</style>

--- a/astro-src/components/BuildingsComponent.astro
+++ b/astro-src/components/BuildingsComponent.astro
@@ -236,16 +236,4 @@ declare global {
 window.buildingsComponentData = buildingsComponentData;
 </script>
 
-<style>
 
-/* Smooth loading transitions */
-[x-cloak] {
-    display: none !important;
-}
-
-/* Hide inactive tabs */
-.hidden {
-    display: none !important;
-}
-
-</style>

--- a/astro-src/components/building/TabPanels.astro
+++ b/astro-src/components/building/TabPanels.astro
@@ -66,11 +66,4 @@ export interface Props {
 
 </div>
 
-<style>
 
-/* Hide elements initially to prevent flash of content */
-[x-cloak] {
-    display: none !important;
-}
-
-</style>

--- a/astro-src/components/forms/BaseInput.astro
+++ b/astro-src/components/forms/BaseInput.astro
@@ -153,40 +153,4 @@ const containerClasses = _.compact([
     )}
 </div>
 
-<style>
 
-    /* Floating label styles to match building component pattern */
-    .floating-label {
-        position: relative;
-        display: block;
-    }
-
-    .floating-label span:first-of-type {
-        position: absolute;
-        top: 0.5rem;
-        left: 0.75rem;
-        font-size: 0.875rem;
-        line-height: 1.25rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.6));
-        pointer-events: none;
-        transition: all 0.2s ease;
-        background-color: var(--fallback-b1, oklch(var(--b1)));
-        padding: 0 0.25rem;
-    }
-
-    .floating-label input:focus ~ span:first-of-type,
-    .floating-label input:not(:placeholder-shown) ~ span:first-of-type {
-        top: -0.5rem;
-        font-size: 0.75rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.8));
-    }
-
-    .floating-label input:focus ~ span:first-of-type {
-        color: var(--fallback-p, oklch(var(--p)));
-    }
-
-    .floating-label input.input-error:focus ~ span:first-of-type {
-        color: var(--fallback-er, oklch(var(--er)));
-    }
-
-</style>

--- a/astro-src/components/forms/BaseSelect.astro
+++ b/astro-src/components/forms/BaseSelect.astro
@@ -117,48 +117,4 @@ const containerClasses = _.compact([
     )}
 </label>
 
-<style>
 
-    /* Floating label styles for select */
-    .floating-label.select-label {
-        position: relative;
-        display: block;
-    }
-
-    .floating-label.select-label span:first-of-type {
-        position: absolute;
-        top: 0.5rem;
-        left: 0.75rem;
-        font-size: 0.875rem;
-        line-height: 1.25rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.6));
-        pointer-events: none;
-        transition: all 0.2s ease;
-        background-color: var(--fallback-b1, oklch(var(--b1)));
-        padding: 0 0.25rem;
-        z-index: 1;
-    }
-
-    .floating-label.select-label select:focus ~ span:first-of-type,
-    .floating-label.select-label select:not(:invalid) ~ span:first-of-type,
-    .floating-label.select-label select:not([value=""]) ~ span:first-of-type {
-        top: -0.5rem;
-        font-size: 0.75rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.8));
-    }
-
-    .floating-label.select-label select:focus ~ span:first-of-type {
-        color: var(--fallback-p, oklch(var(--p)));
-    }
-
-    .floating-label.select-label select.select-error:focus ~ span:first-of-type {
-        color: var(--fallback-er, oklch(var(--er)));
-    }
-
-    /* Ensure select has proper padding for floating label */
-    .floating-label.select-label select {
-        padding-top: 1.25rem;
-        padding-bottom: 0.5rem;
-    }
-
-</style>

--- a/astro-src/components/forms/BaseTextarea.astro
+++ b/astro-src/components/forms/BaseTextarea.astro
@@ -53,11 +53,18 @@ const {
 const shouldShowLabel = showLabel && label;
 
 // Build textarea classes
+const resizeClassMap = {
+    none: 'resize-none',
+    both: 'resize',
+    horizontal: 'resize-x',
+    vertical: 'resize-y'
+};
+
 const textareaClasses = _.compact([
     'textarea',
     'w-full',
     error ? 'textarea-error' : '',
-    `resize-${resize}`,
+    resizeClassMap[resize],
     characterCountInside && maxlength ? 'pb-8' : '', // Extra padding for character count
     textareaClass
 ]).join(' ');
@@ -160,63 +167,4 @@ const containerClasses = _.compact([
     )}
 </div>
 
-<style>
 
-    /* Floating label styles for textarea */
-    .floating-label.textarea-label {
-        position: relative;
-        display: block;
-    }
-
-    .floating-label.textarea-label span:first-of-type {
-        position: absolute;
-        top: 0.75rem;
-        left: 0.75rem;
-        font-size: 0.875rem;
-        line-height: 1.25rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.6));
-        pointer-events: none;
-        transition: all 0.2s ease;
-        background-color: var(--fallback-b1, oklch(var(--b1)));
-        padding: 0 0.25rem;
-        z-index: 1;
-    }
-
-    .floating-label.textarea-label textarea:focus ~ span:first-of-type,
-    .floating-label.textarea-label textarea:not(:placeholder-shown) ~ span:first-of-type {
-        top: -0.5rem;
-        font-size: 0.75rem;
-        color: var(--fallback-bc, oklch(var(--bc) / 0.8));
-    }
-
-    .floating-label.textarea-label textarea:focus ~ span:first-of-type {
-        color: var(--fallback-p, oklch(var(--p)));
-    }
-
-    .floating-label.textarea-label textarea.textarea-error:focus ~ span:first-of-type {
-        color: var(--fallback-er, oklch(var(--er)));
-    }
-
-    /* Ensure textarea has proper padding for floating label */
-    .floating-label.textarea-label textarea {
-        padding-top: 1.5rem;
-    }
-
-    /* Resize utilities */
-    .resize-none {
-        resize: none;
-    }
-
-    .resize-both {
-        resize: both;
-    }
-
-    .resize-horizontal {
-        resize: horizontal;
-    }
-
-    .resize-vertical {
-        resize: vertical;
-    }
-
-</style>

--- a/astro-src/components/forms/DropdownSelect.astro
+++ b/astro-src/components/forms/DropdownSelect.astro
@@ -106,7 +106,7 @@ const buttonClasses = filter([
             }
         }`}
     >
-        <details x-ref="dropdownDetails">
+        <details x-ref="dropdownDetails" class="group">
             <summary
               tabindex="0"
               class={buttonClasses}
@@ -121,7 +121,7 @@ const buttonClasses = filter([
                     {placeholder}
                 </span>
                 <svg
-                  class="w-4 h-4 transition-transform"
+                  class="w-4 h-4 transition-transform group-open:rotate-180"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -137,7 +137,7 @@ const buttonClasses = filter([
 
             <ul
               tabindex="0"
-              class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-full mt-1 border border-base-300 max-h-60 overflow-auto"
+              class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-full mt-1 border border-base-300 max-h-60 overflow-auto left-0 right-0 top-full"
               role="listbox"
             >
                 {map(normalizedOptions, option => (
@@ -146,7 +146,7 @@ const buttonClasses = filter([
                           @click={`selectOption('${option.value}')`}
                           class:list={[
                                 'justify-between',
-                                option.disabled ? 'disabled' : ''
+                                option.disabled ? 'opacity-50 cursor-not-allowed pointer-events-none' : ''
                             ]}
                           class={`selectedValue === '${option.value}' ? 'active' : ''`}
                           role="option"
@@ -190,36 +190,4 @@ const buttonClasses = filter([
     )}
 </div>
 
-<style>
 
-    /* Ensure dropdown doesn't get cut off */
-    .dropdown-content {
-        position: absolute;
-        top: 100%;
-        left: 0;
-        right: 0;
-    }
-
-    /* Style disabled options */
-    .menu li a.disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-        pointer-events: none;
-    }
-
-    /* Ensure proper focus styles */
-    .dropdown summary:focus {
-        outline: 2px solid transparent;
-        outline-offset: 2px;
-    }
-
-    .dropdown summary:focus-visible {
-        box-shadow: 0 0 0 2px var(--fallback-b1, oklch(var(--b1))), 0 0 0 4px var(--fallback-p, oklch(var(--p)));
-    }
-
-    /* Rotate chevron when open */
-    details[open] summary svg {
-        transform: rotate(180deg);
-    }
-
-</style>

--- a/astro-src/styles/global.css
+++ b/astro-src/styles/global.css
@@ -28,3 +28,65 @@ main {
 }
 
 /* Toast styling now handled by DaisyUI positioning classes */
+
+/* Floating label styles */
+.floating-label {
+    position: relative;
+    display: block;
+}
+
+.floating-label span:first-of-type {
+    position: absolute;
+    top: 0.5rem;
+    left: 0.75rem;
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+    color: var(--fallback-bc, oklch(var(--bc) / 0.6));
+    pointer-events: none;
+    transition: all 0.2s ease;
+    background-color: var(--fallback-b1, oklch(var(--b1)));
+    padding: 0 0.25rem;
+    z-index: 1;
+}
+
+.floating-label.textarea-label span:first-of-type {
+    top: 0.75rem;
+}
+
+.floating-label input:focus ~ span:first-of-type,
+.floating-label input:not(:placeholder-shown) ~ span:first-of-type,
+.floating-label.textarea-label textarea:focus ~ span:first-of-type,
+.floating-label.textarea-label textarea:not(:placeholder-shown) ~ span:first-of-type,
+.floating-label.select-label select:focus ~ span:first-of-type,
+.floating-label.select-label select:not(:invalid) ~ span:first-of-type,
+.floating-label.select-label select:not([value=""]) ~ span:first-of-type {
+    top: -0.5rem;
+    font-size: 0.75rem;
+    color: var(--fallback-bc, oklch(var(--bc) / 0.8));
+}
+
+.floating-label input:focus ~ span:first-of-type,
+.floating-label.textarea-label textarea:focus ~ span:first-of-type,
+.floating-label.select-label select:focus ~ span:first-of-type {
+    color: var(--fallback-p, oklch(var(--p)));
+}
+
+.floating-label input.input-error:focus ~ span:first-of-type,
+.floating-label.textarea-label textarea.textarea-error:focus ~ span:first-of-type,
+.floating-label.select-label select.select-error:focus ~ span:first-of-type {
+    color: var(--fallback-er, oklch(var(--er)));
+}
+
+.floating-label.textarea-label textarea {
+    padding-top: 1.5rem;
+}
+
+.floating-label.select-label select {
+    padding-top: 1.25rem;
+    padding-bottom: 0.5rem;
+}
+
+/* Building manager container */
+.building-manager {
+    min-height: 200px;
+}

--- a/astro-src/styles/global.css
+++ b/astro-src/styles/global.css
@@ -3,90 +3,95 @@
 @plugin "daisyui" {
     themes: emerald --default, dark --prefersdark;
 }
-
-main {
-    margin: auto;
-    max-width: 1200px;
-    padding: 0.75rem 1rem;
-}
-
-@media (min-width: 640px) {
+@layer base {
     main {
-        padding: 1rem 1.5rem;
+        margin: auto;
+        max-width: 1200px;
+        padding: 0.75rem 1rem;
+    }
+
+    @media (min-width: 640px) {
+        main {
+            padding: 1rem 1.5rem;
+        }
+    }
+
+    @media (min-width: 1024px) {
+        main {
+            padding: 1.5rem 2rem;
+        }
     }
 }
 
-@media (min-width: 1024px) {
-    main {
-        padding: 1.5rem 2rem;
+@layer utilities {
+    /* Hide elements with x-cloak until Alpine.js initializes */
+    [x-cloak] {
+        display: none !important;
     }
-}
-
-/* Hide elements with x-cloak until Alpine.js initializes */
-[x-cloak] {
-    display: none !important;
 }
 
 /* Toast styling now handled by DaisyUI positioning classes */
 
-/* Floating label styles */
-.floating-label {
-    position: relative;
-    display: block;
-}
+@layer components {
+    /* Floating label styles */
+    .floating-label {
+        position: relative;
+        display: block;
+    }
 
-.floating-label span:first-of-type {
-    position: absolute;
-    top: 0.5rem;
-    left: 0.75rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    color: var(--fallback-bc, oklch(var(--bc) / 0.6));
-    pointer-events: none;
-    transition: all 0.2s ease;
-    background-color: var(--fallback-b1, oklch(var(--b1)));
-    padding: 0 0.25rem;
-    z-index: 1;
-}
+    .floating-label span:first-of-type {
+        position: absolute;
+        top: 0.5rem;
+        left: 0.75rem;
+        font-size: 0.875rem;
+        line-height: 1.25rem;
+        color: var(--fallback-bc, oklch(var(--bc) / 0.6));
+        pointer-events: none;
+        transition: all 0.2s ease;
+        background-color: var(--fallback-b1, oklch(var(--b1)));
+        padding: 0 0.25rem;
+        z-index: 1;
+    }
 
-.floating-label.textarea-label span:first-of-type {
-    top: 0.75rem;
-}
+    .floating-label.textarea-label span:first-of-type {
+        top: 0.75rem;
+    }
 
-.floating-label input:focus ~ span:first-of-type,
-.floating-label input:not(:placeholder-shown) ~ span:first-of-type,
-.floating-label.textarea-label textarea:focus ~ span:first-of-type,
-.floating-label.textarea-label textarea:not(:placeholder-shown) ~ span:first-of-type,
-.floating-label.select-label select:focus ~ span:first-of-type,
-.floating-label.select-label select:not(:invalid) ~ span:first-of-type,
-.floating-label.select-label select:not([value=""]) ~ span:first-of-type {
-    top: -0.5rem;
-    font-size: 0.75rem;
-    color: var(--fallback-bc, oklch(var(--bc) / 0.8));
-}
+    .floating-label input:focus ~ span:first-of-type,
+    .floating-label input:not(:placeholder-shown) ~ span:first-of-type,
+    .floating-label.textarea-label textarea:focus ~ span:first-of-type,
+    .floating-label.textarea-label textarea:not(:placeholder-shown) ~ span:first-of-type,
+    .floating-label.select-label select:focus ~ span:first-of-type,
+    .floating-label.select-label select:not(:invalid) ~ span:first-of-type,
+    .floating-label.select-label select:not([value=""]) ~ span:first-of-type {
+        top: -0.5rem;
+        font-size: 0.75rem;
+        color: var(--fallback-bc, oklch(var(--bc) / 0.8));
+    }
 
-.floating-label input:focus ~ span:first-of-type,
-.floating-label.textarea-label textarea:focus ~ span:first-of-type,
-.floating-label.select-label select:focus ~ span:first-of-type {
-    color: var(--fallback-p, oklch(var(--p)));
-}
+    .floating-label input:focus ~ span:first-of-type,
+    .floating-label.textarea-label textarea:focus ~ span:first-of-type,
+    .floating-label.select-label select:focus ~ span:first-of-type {
+        color: var(--fallback-p, oklch(var(--p)));
+    }
 
-.floating-label input.input-error:focus ~ span:first-of-type,
-.floating-label.textarea-label textarea.textarea-error:focus ~ span:first-of-type,
-.floating-label.select-label select.select-error:focus ~ span:first-of-type {
-    color: var(--fallback-er, oklch(var(--er)));
-}
+    .floating-label input.input-error:focus ~ span:first-of-type,
+    .floating-label.textarea-label textarea.textarea-error:focus ~ span:first-of-type,
+    .floating-label.select-label select.select-error:focus ~ span:first-of-type {
+        color: var(--fallback-er, oklch(var(--er)));
+    }
 
-.floating-label.textarea-label textarea {
-    padding-top: 1.5rem;
-}
+    .floating-label.textarea-label textarea {
+        padding-top: 1.5rem;
+    }
 
-.floating-label.select-label select {
-    padding-top: 1.25rem;
-    padding-bottom: 0.5rem;
-}
+    .floating-label.select-label select {
+        padding-top: 1.25rem;
+        padding-bottom: 0.5rem;
+    }
 
-/* Building manager container */
-.building-manager {
-    min-height: 200px;
+    /* Building manager container */
+    .building-manager {
+        min-height: 200px;
+    }
 }


### PR DESCRIPTION
## Summary
- replace inline dropdown tweaks with Tailwind/DaisyUI utilities
- centralize floating label and x-cloak rules in `astro-src/styles/global.css`
- map textarea resize options to Tailwind utilities

## Testing
- `bun run full-test` *(fails: Cannot find package '@hughescr/eslint-config-default')*

------
https://chatgpt.com/codex/tasks/task_e_68a79a02ad10832f9ea3b35b8b5da481