### PR TITLE
feat: add reusable toast component

### DIFF
--- a/astro-src/components/common/Toast.astro
+++ b/astro-src/components/common/Toast.astro
@@ -1,0 +1,75 @@
+---
+---
+<div
+  x-data="{
+        showToast: false,
+        toastMessage: '',
+        toastType: 'success',
+        autoHideTimer: null,
+        init() {
+            window.toastController = this;
+        },
+        showAndHideToast(message, type) {
+            this.toastMessage = message;
+            this.toastType = type;
+            this.showToast = true;
+
+            if (this.autoHideTimer) {
+                clearTimeout(this.autoHideTimer);
+                this.autoHideTimer = null;
+            }
+
+            if (type !== 'error') {
+                const baseTime = 3000;
+                const readingTime = Math.min(Math.max(message.length * 100, baseTime), 15000);
+                this.autoHideTimer = setTimeout(() => {
+                    this.showToast = false;
+                    this.autoHideTimer = null;
+                }, readingTime);
+            }
+        },
+        dismissToast() {
+            if (this.autoHideTimer) {
+                clearTimeout(this.autoHideTimer);
+                this.autoHideTimer = null;
+            }
+            this.showToast = false;
+        }
+    }"
+    @show-toast.window="showAndHideToast($event.detail.message, $event.detail.type || $event.detail.toastType)"
+    @toast:show.window="showAndHideToast($event.detail.message, $event.detail.type || $event.detail.toastType)"
+  class="toast toast-top toast-end"
+  x-show="showToast"
+  x-transition.opacity
+>
+    <div
+        class="alert cursor-pointer relative pr-12"
+        x-bind:class="{
+            'alert-error': toastType === 'error',
+            'alert-success': toastType === 'success',
+            'alert-warning': toastType === 'warning',
+            'alert-info': toastType === 'info'
+        }"
+        @click="window.toastController?.dismissToast?.()"
+      role="status"
+      x-bind:aria-live="toastType === 'error' ? 'assertive' : 'polite'"
+    >
+        <span x-text="toastMessage" class="flex-1"></span>
+
+          <button
+            @click.stop="window.toastController?.dismissToast?.()"
+            class="btn btn-ghost btn-sm btn-square absolute top-2 right-2"
+            aria-label="Dismiss notification"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+        </button>
+    </div>
+</div>

--- a/astro-src/layouts/Layout.astro
+++ b/astro-src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import BaseHead from '../components/BaseHead.astro';
 import Footer from '../components/Footer.astro';
+import Toast from '../components/common/Toast.astro';
 const { title } = Astro.props;
 import '../styles/global.css';
 ---
@@ -38,88 +39,12 @@ import '../styles/global.css';
             </main>
         </div>
 
-        <!-- Global Toast Container -->
-        <div
-          x-data="{
-                showToast: false,
-                toastMessage: '',
-                toastType: 'success',
-                autoHideTimer: null,
-                init() {
-                    window.toastController = this;
-                },
-                showAndHideToast(message, type) {
-                    this.toastMessage = message;
-                    this.toastType = type;
-                    this.showToast = true;
-
-                    // Clear existing timer if any
-                    if (this.autoHideTimer) {
-                        clearTimeout(this.autoHideTimer);
-                        this.autoHideTimer = null;
-                    }
-
-                    // Only auto-hide non-error toasts
-                    if (type !== 'error') {
-                        // Calculate display time based on message length
-                        // Base time: 3 seconds + (message length / 10 chars per second reading speed)
-                        // Min: 3 seconds, Max: 15 seconds
-                        const baseTime = 3000;
-                        const readingTime = Math.min(Math.max(message.length * 100, baseTime), 15000);
-
-                        this.autoHideTimer = setTimeout(() => {
-                            this.showToast = false;
-                            this.autoHideTimer = null;
-                        }, readingTime);
-                    }
-                },
-                dismissToast() {
-                    if (this.autoHideTimer) {
-                        clearTimeout(this.autoHideTimer);
-                        this.autoHideTimer = null;
-                    }
-                    this.showToast = false;
-                }
-            }"
-          @show-toast.window="showAndHideToast($event.detail.message, $event.detail.type)"
-          class="toast toast-top toast-end"
-          x-show="showToast"
-          x-transition.opacity
-        >
-            <div
-              class="alert cursor-pointer relative pr-12"
-              x-bind:class="{
-                'alert-error': toastType === 'error',
-                'alert-success': toastType === 'success',
-                'alert-warning': toastType === 'warning',
-                'alert-info': toastType === 'info'
-              }"
-              @click="window.toastController?.dismissToast?.()"
-            >
-                <span x-text="toastMessage" class="flex-1"></span>
-
-                <!-- Close button -->
-                <button
-                  @click.stop="window.toastController?.dismissToast?.()"
-                  class="btn btn-ghost btn-sm btn-square absolute top-2 right-2"
-                  aria-label="Dismiss notification"
-                >
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
+        <Toast />
 
         <Footer />
 
-        <!-- Global showToast function -->
-        <script>
-            window.showToast = function(message, type) {
-                window.dispatchEvent(new CustomEvent('show-toast', {
-                    detail: { message, type }
-                }));
-            };
+        <script type="module">
+            import '../lib/utils/show-toast.ts';
         </script>
     </body>
 </html>

--- a/astro-src/lib/utils/show-toast.ts
+++ b/astro-src/lib/utils/show-toast.ts
@@ -1,0 +1,7 @@
+import type { ToastType } from '../types/alpine-state';
+
+window.showToast = function(message: string, type: ToastType) {
+    window.dispatchEvent(new CustomEvent('show-toast', {
+        detail: { message, type }
+    }));
+};


### PR DESCRIPTION
## Summary
- extract toast UI into `<Toast/>` component with ARIA live region
- create `showToast` utility for global toast API
- consume new component in main layout

## Testing
- `bun run full-test` *(fails: Property 'BuildingsUnits' does not exist on type 'Resource')*

------
https://chatgpt.com/codex/tasks/task_e_68a799f52380832fafa1e130e1f14778