### PR TITLE
feat: add floorplan creation button

### DIFF
--- a/astro-src/components/building/tabs/FloorplansUnitsTab.astro
+++ b/astro-src/components/building/tabs/FloorplansUnitsTab.astro
@@ -15,7 +15,15 @@ export type Props = Record<string, never>;
         <div class="card-body p-4 sm:p-6">
             <div class="flex justify-between items-center mb-4">
                 <h3 class="card-title text-xl">Floorplans (Unit Types)</h3>
-                <div class="badge badge-primary badge-lg" x-text="(unitTypes?.length || 0) + ' types'"></div>
+                <div class="flex items-center gap-2">
+                    <div class="badge badge-primary badge-lg" x-text="(unitTypes?.length || 0) + ' types'"></div>
+                    <button @click="openAddUnitTypeDialog()" class="btn btn-primary btn-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+                        </svg>
+                        Add Floorplan
+                    </button>
+                </div>
             </div>
             <div class="text-base-content/70 mb-4">
                 Define unit types that serve as templates for individual units. Units can inherit settings from their floorplan and override them as needed.

--- a/tests/components/building/tabs/FloorplansUnitsTab.test.ts
+++ b/tests/components/building/tabs/FloorplansUnitsTab.test.ts
@@ -10,6 +10,9 @@ import {
     jest,
     resetAllMocks
 } from '../test-setup';
+import { UnitTypeManagement } from '../../../../astro-src/lib/building/state/unitTypeManagement';
+import type { UnitTypeManagementState } from '../../../../astro-src/lib/building/state/unitTypeManagement';
+import type { UnitTypeData } from '../../../../astro-src/types';
 
 describe('FloorplansUnitsTab Component Logic', () => {
     let mockBuildingData: ReturnType<typeof createTestBuildingData>;
@@ -211,6 +214,21 @@ describe('FloorplansUnitsTab Component Logic', () => {
                     expect(typeof unit.baths).toBe('number');
                 }
             });
+        });
+    });
+
+    describe('Unit type dialog controls', () => {
+        it('should toggle add unit type dialog state', () => {
+            const state: UnitTypeManagementState = {
+                unitTypes: [],
+                showAddUnitTypeDialog: false,
+                newUnitType: {} as Partial<UnitTypeData>
+            };
+            const management = new UnitTypeManagement(state);
+            management.openAddUnitTypeDialog();
+            expect(state.showAddUnitTypeDialog).toBe(true);
+            management.closeAddUnitTypeDialog();
+            expect(state.showAddUnitTypeDialog).toBe(false);
         });
     });
 


### PR DESCRIPTION
## Summary
- allow adding floorplans from Floorplans & Units tab header
- cover unit type dialog state in tests

## Testing
- `bunx eslint astro-src/components/building/tabs/FloorplansUnitsTab.astro tests/components/building/tabs/FloorplansUnitsTab.test.ts --fix`
- `bun test tests/components/building/tabs/FloorplansUnitsTab.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a79fa3e050832fa4765df3b68a224a