### PR TITLE
feat: add city screening presets

### DIFF
--- a/astro-src/components/forms/ScreeningCriteriaForm.astro
+++ b/astro-src/components/forms/ScreeningCriteriaForm.astro
@@ -128,6 +128,32 @@ const xData = `{
                     rentalHistory: false
                 });
                 break;
+            case 'portland':
+                Object.assign(model, {
+                    incomeRatio: 2.5,
+                    minCreditScore: 500,
+                    maxOccupantsPerBedroom: 2,
+                    backgroundCheckRequired: true,
+                    evictionHistory: true,
+                    criminalHistory: true,
+                    references: 2,
+                    employmentVerification: true,
+                    rentalHistory: true
+                });
+                break;
+            case 'sanFrancisco':
+                Object.assign(model, {
+                    incomeRatio: 3,
+                    minCreditScore: 700,
+                    maxOccupantsPerBedroom: 2,
+                    backgroundCheckRequired: true,
+                    evictionHistory: true,
+                    criminalHistory: true,
+                    references: 2,
+                    employmentVerification: true,
+                    rentalHistory: true
+                });
+                break;
             case 'minimal':
                 Object.assign(model, {
                     incomeRatio: undefined,
@@ -233,6 +259,22 @@ const xData = `{
                   disabled={disabled}
                 >
                     Minimal
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline"
+                  x-on:click="applyPreset('portland')"
+                  disabled={disabled}
+                >
+                    Portland
+                </button>
+                <button
+                  type="button"
+                  class="btn btn-outline"
+                  x-on:click="applyPreset('sanFrancisco')"
+                  disabled={disabled}
+                >
+                    San Francisco
                 </button>
             </div>
         </div>

--- a/tests/components/ScreeningCriteriaForm.test.ts
+++ b/tests/components/ScreeningCriteriaForm.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { promises as fs } from 'fs';
+
+let componentSrc: string;
+
+beforeEach(async () => {
+    if(!componentSrc) {
+        componentSrc = await fs.readFile(new URL('../../astro-src/components/forms/ScreeningCriteriaForm.astro', import.meta.url), 'utf8');
+    }
+});
+
+describe('ScreeningCriteriaForm presets', () => {
+    it('includes Portland preset with legal limits', () => {
+        expect(componentSrc).toContain("applyPreset('portland')");
+        expect(componentSrc).toContain('Portland');
+        expect(componentSrc).toContain('incomeRatio: 2.5');
+        expect(componentSrc).toContain('minCreditScore: 500');
+    });
+
+    it('includes San Francisco preset with landlord-friendly values', () => {
+        expect(componentSrc).toContain("applyPreset('sanFrancisco')");
+        expect(componentSrc).toContain('San Francisco');
+        expect(componentSrc).toContain('incomeRatio: 3');
+        expect(componentSrc).toContain('minCreditScore: 700');
+    });
+});


### PR DESCRIPTION
## Summary
- add Portland and San Francisco screening criteria presets
- test presets exist with expected values

## Testing
- `bun test`
- `bun run full-test` *(fails: BuildingManager.astro lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a79efffd88832fac5717d33e561ef7